### PR TITLE
Fix get-selenium-versions not parsing correctly

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (def project 'webica)
 (def description "A Clojure binding for Selenium WebDriver")
 (def project-url "https://github.com/tmarble/webica")
-(def selenium-version "3.0.0-beta2")
+(def selenium-version "3.0.1")
 (def webica-version "-clj0")
 (def version (str selenium-version webica-version))
 
@@ -14,8 +14,8 @@
                     [me.raynes/fs "1.4.6"]
                     [avenir "0.2.1"]
                     [com.taoensso/timbre "4.7.3"]
+                    [pom-versions "0.1.1"]
                     ;; testing/development ONLY
-                    [aleph "0.4.2-alpha6" :scope "test"]
                     [adzerk/boot-test "1.1.2" :scope "test"]
                     [adzerk/bootlaces "0.1.13" :scope "test"]]
                   ['org.seleniumhq.selenium/selenium-java selenium-version]))
@@ -27,7 +27,7 @@
 (bootlaces! version)
 
 (task-options!
-  test {:namespaces #{'testing.webica.core}}
+ test {:namespaces #{'testing.webica.core}}
   pom {:project     project
        :version     version
        :description description

--- a/generate/webica/generate.clj
+++ b/generate/webica/generate.clj
@@ -8,36 +8,21 @@
   "Generation functions to make Clojure wrapper for Selenium WebDriver"
   (:require [clojure.string :as string]
             [clojure.java.shell :refer [sh]]
+            [pom-versions.core :refer [get-versions] :as pv]
             [camel-snake-kebab.core :as translate]
             [webica.core :as w]
-            [aleph.http :as http]
-            [byte-streams :as bs]
             [me.raynes.fs :as fs]))
 
 (def #^{:added "clj0"}
   selenium-maven-url
   "Repository URL to determine published Selenium versions"
-  "http://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/")
-
-(def #^{:added "clj0"}
-  firefox-user-agent
-  "Maven will refuse to reply to a query if it thinks you're a robot :)"
-  "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/34.0")
+  "http://repo1.maven.org/maven2/org/seleniumhq/selenium/selenium-java/maven-metadata.xml")
 
 (defn get-selenium-versions
   "Returns a vector of known Selenium versions (in order)"
   {:added "clj0"}
-  []
-  (let [options {:headers {"User-Agent" firefox-user-agent}}
-        {:keys [status body]} @(http/get selenium-maven-url options)]
-    (if (not= status 200)
-      (throw (AssertionError.
-               (str "Unable to get Selenium versions: " status)))
-      (let [html (bs/to-string body)
-            vers (re-seq #"href=\"\d.*\"" html)
-            get-ver (fn [x] (string/replace x #"href=\"(.*)/\"" "$1"))
-            versions (vec (sort (map get-ver vers)))]
-        versions))))
+  ([]
+   (pv/get-versions (slurp selenium-maven-url))))
 
 (defn- pprint-coercions [coercions]
   (let [n (count coercions)]

--- a/test/testing/webica/core.clj
+++ b/test/testing/webica/core.clj
@@ -37,12 +37,12 @@
 (deftest testing-webica-core
   (testing "testing-webica-core"
     (is (= expected-title
-          (let [_ (firefox/start-firefox)
-                title (cheese)]
-            (browser/quit)
-            title)))
+           (let [_ (firefox/start-firefox)
+                 title (cheese)]
+             (browser/quit)
+             title)))
     (is (= expected-title
-          (let [_ (chrome/start-chrome)
-                title (cheese)]
-            (browser/quit)
-            title)))))
+           (let [_ (chrome/start-chrome)
+                 title (cheese)]
+             (browser/quit)
+             title)))))


### PR DESCRIPTION
This is the new PR version that eliminate the duplication of the previous PR that I raised earlier. The function to `get-selenium-versions` are now handled by [pom-versions](https://github.com/agilecreativity/pom-versions) library. The library is self-contained and provide a better way to test the helper functionality independently. 
For more information please see the [test](https://github.com/agilecreativity/pom-versions/blob/master/test/pom_versions/core_test.clj)

- Read the meta-data directly from pom-metadata.xml file
- Update default selenium version to 3.0.1
- Remove aleph from dependency
- Use pom-versions library in get-selenium-versions