### PR TITLE
Fix problem with pom-versions 0.1.1 and add support for ExpectedConditions

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -8,13 +8,13 @@
 (set-env!
   :source-paths #{"src" "test"}
   :dependencies (conj
-                  '[[org.clojure/clojure "1.9.0-alpha10" :scope "provided"]
+                  '[[org.clojure/clojure "1.9.0-alpha15" :scope "provided"]
                     [camel-snake-kebab "0.4.0"]
                     [environ "1.1.0"]
                     [me.raynes/fs "1.4.6"]
                     [avenir "0.2.1"]
                     [com.taoensso/timbre "4.7.3"]
-                    [pom-versions "0.1.1"]
+                    [pom-versions "0.1.2"]
                     ;; testing/development ONLY
                     [adzerk/boot-test "1.1.2" :scope "test"]
                     [adzerk/bootlaces "0.1.13" :scope "test"]]

--- a/generate/webica/core.clj
+++ b/generate/webica/core.clj
@@ -31,7 +31,8 @@ NOTE: load this namespace first when using webica."
            [org.openqa.selenium.remote
             RemoteWebDriver RemoteWebElement]
            [org.openqa.selenium.support.ui
-            WebDriverWait]))
+            WebDriverWait
+            ExpectedConditions]))
 
 ;; yes, the sleep function really wants to live somewhere else
 (defn sleep
@@ -217,6 +218,7 @@ on how to generate the Clojure source code."
    WebDriver {:exclude '[get]}
    WebDriverWait {:extra web-driver-wait-extra
                   :coercions web-driver-wait-coercions}
+   ExpectedConditions {:exclude '[not or and]}
    WebElement {}})
 
 (def #^{:added "clj0"}

--- a/src/webica/core.clj
+++ b/src/webica/core.clj
@@ -31,7 +31,8 @@ NOTE: load this namespace first when using webica."
            [org.openqa.selenium.remote
             RemoteWebDriver RemoteWebElement]
            [org.openqa.selenium.support.ui
-            WebDriverWait]))
+            WebDriverWait
+            ExpectedConditions]))
 
 ;; yes, the sleep function really wants to live somewhere else
 (defn sleep
@@ -217,6 +218,7 @@ on how to generate the Clojure source code."
    WebDriver {:exclude '[get]}
    WebDriverWait {:extra web-driver-wait-extra
                   :coercions web-driver-wait-coercions}
+   ExpectedConditions {:exclude '[not or and]}
    WebElement {}})
 
 (def #^{:added "clj0"}

--- a/src/webica/expected_conditions.clj
+++ b/src/webica/expected_conditions.clj
@@ -1,0 +1,9 @@
+(ns webica.expected-conditions
+  "Clojure binding for Selenium class ExpectedConditions"
+  (:refer-clojure :exclude [not or and])
+  (:require [clojure.core :as clj]
+            [webica.core :as w])
+  (:import [org.openqa.selenium.support.ui
+            ExpectedConditions]))
+
+(w/intern-java ExpectedConditions *ns*)


### PR DESCRIPTION
Hi @tmarble,

I just found minor problem with [pom-version-0.1.1](https://github.com/agilecreativity/pom-versions/commit/33020830570f0369dcb545d709c9b36fbd07ec93) that the `resources` mentioned in `resources-path` is not checked in as part of git commit.

Also I would like to add the support for [ExpectedCondtions](https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html) as I found it used to be very useful when we have to work with any pages that take sometime to load thus we can use various wait conditions in this class.

Please feel free to adjust anything or let me know if you like me to update anything for this PR.

Cheers,
Burin