### PR TITLE
Add init-webdriver-wait and wait-until

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pom.xml.asc
 
 # Editor artifacts
 .nrepl-port
+.nrepl-history
 *~
 
 # silly Mac filesystem

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -1,36 +1,37 @@
 #!/usr/bin/env boot
 ;; -*- Mode: clojure; coding: utf-8  -*-
-(set-env! :dependencies '[[webica "3.0.0-beta2-clj0"]])
+(set-env! :dependencies '[[webica "3.4.0-clj0"]])
 
 (require
   '[clojure.string :as string]
   '[webica.core :as w] ;; must always be first
-  '[webica.by :as by]
+  '[webica.by :refer [partial-link-text] :as by]
   '[webica.web-driver :as driver]
   '[webica.firefox-driver :as firefox]
+  '[webica.chrome-driver :as chrome]
   '[webica.web-element :as element]
   '[webica.web-driver-wait :as wait]
+  '[webica.expected-conditions :refer [presence-of-element-located] :as ec]
   '[webica.remote-web-driver :as browser])
 
-(defn lmgtfy [search]
+(defn lmgtfy [wdriver search]
   (browser/get "http://www.google.com")
   (let [q (browser/find-element (by/name "q"))]
     (element/send-keys q search)
     (element/submit q)
-    (wait/until (wait/instance 10)
-      (wait/condition
-        (fn [driver]
-          (string/starts-with?
-            (string/lower-case (driver/get-title driver))
-            (string/lower-case search)))))
-    (println "Was that so hard?")
-    (w/sleep 10)))
+    (wait/wait-until wdriver
+                     presence-of-element-located
+                     partial-link-text
+                     search)
+    (println "Was that so hard?")))
 
 (defn -main
   "Webica example of 'Let me Google that for you'"
   [& args]
   (let [search (if (empty? args) "Clojure Conj 2016"
                    (apply str (interpose " " args)))]
-    (firefox/start-firefox)
-    (lmgtfy search)
+    ;;(firefox/start-firefox)
+    (chrome/start-chrome)
+    (let [wdriver (wait/init-webdriver-wait (driver/get-instance))]
+      (lmgtfy wdriver search))
     (browser/quit)))

--- a/src/webica/web_driver_wait.clj
+++ b/src/webica/web_driver_wait.clj
@@ -23,3 +23,32 @@
         'cheese!'))))"
   [apply-fn]
   (Condition. apply-fn))
+
+(defn init-webdriver-wait
+  "Create the WebDriverWait from existing WebDriver object."
+  ([driver]
+    (init-webdriver-wait driver 10))
+  ([driver max-timeouts]
+    ;; Always maximize window
+    (-> driver
+        .manage
+        .window
+        .maximize)
+   ;; Manage the implicit timeouts
+   (.implicitlyWait
+     (-> driver
+         .manage
+         .timeouts)
+     max-timeouts java.util.concurrent.TimeUnit/SECONDS)
+   (let [wait-instance (org.openqa.selenium.support.ui.WebDriverWait. driver max-timeouts)]
+     wait-instance)))
+
+(defn wait-until
+  "Wait until a given condition is met or raise exception if the condition can't be met.
+
+  Example:
+  (wait-until presence-of-element-located
+              xpath
+              \"some-id\")"
+  [wdriver expected-cond-fn by-fn arg]
+  (.until wdriver (expected-cond-fn (by-fn arg))))


### PR DESCRIPTION
Hi @tmarble 

This PR is aim to make it easier to use the [ExpectedConditions](https://github.com/SeleniumHQ/selenium/blob/selenium-3.0.0/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java)

- Update example to use 3.4.0 version of Selenium
- Use wait-until to wait for the condition using expected-condition
- Update .gitignore and minor reformat of the import statement

Please take a look and let me know if you like to adjust anything.

Cheers,
Burin