### PR TITLE
Add support for chrome options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pom.xml.asc
 # silly Mac filesystem
 *.DS_Store*
 *._*
+.nrepl-history

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -1,6 +1,6 @@
 #!/usr/bin/env boot
 ;; -*- Mode: clojure; coding: utf-8  -*-
-(set-env! :dependencies '[[webica "3.0.0-beta2-clj0"]])
+(set-env! :dependencies '[[webica "3.4.0-clj0"]])
 
 (require
   '[clojure.string :as string]

--- a/generate/webica/core.clj
+++ b/generate/webica/core.clj
@@ -101,7 +101,37 @@ NOTE: load this namespace first when using webica."
 (def #^{:added "clj0"}
   chrome-driver-extra
   "Extra functions for the chrome-driver ns"
-  "(defn start-chrome [&[chromedriver]]
+  "
+(defn ^:private init-chrome-options
+  \"The default ChromeOptions with the web-driver initialization.
+  e.g.
+  (init-chrome-options \\\"headless\\\"
+                       \\\"--disable-gpu\\\"
+                       \\\"--window-size=1920,1080\\\")\"
+  [& args]
+  (let [chrome-options (org.openqa.selenium.chrome.ChromeOptions.)
+        flags (vec (first args))]
+    ;; Call ChromeOptions.addArguments()
+    (.addArguments chrome-options flags)
+    chrome-options))
+
+(defn start-chrome [chromedriver & args]
+  \"The default chrome options with the web-driver initialization.
+
+  Example Usage:
+
+  (a) Create chrome-driver without chrome-options :
+
+  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\")
+
+  (b) Create chrome-driver with chrome-options :
+
+  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\"
+                ;; Arguments for init-chrome-options above.
+                \\\"headless\\\"                 ;; Run headless (omit to run non-headless)
+                \\\"--disable-gpu\\\"            ;; mandatory argument for Chrome/Chromium 59.0
+                \\\"--window-size=1920,1080\\\") ;; optional but good to have
+  For complete options please see https://goo.gl/DcUcrj\"
   (let [driver-prop \"webdriver.chrome.driver\"
         default-exe (System/getProperty driver-prop)
         chromedriver-system \"/usr/lib/chromium/chromedriver\"
@@ -118,7 +148,9 @@ NOTE: load this namespace first when using webica."
         (RuntimeException.
           (str \"ERROR: chromedriver executable not found:\" chromedriver))))
     (System/setProperty driver-prop chromedriver)
-    (instance)))")
+    (if args
+      (instance (init-chrome-options args))
+      (instance))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra

--- a/src/webica/chrome_driver.clj
+++ b/src/webica/chrome_driver.clj
@@ -10,7 +10,37 @@
 (w/intern-java ChromeDriver *ns*
   {:clear '[quit kill]})
 
-(defn start-chrome [&[chromedriver]]
+
+(defn ^:private init-chrome-options
+  "The default ChromeOptions with the web-driver initialization.
+  e.g.
+  (init-chrome-options \"headless\"
+                       \"--disable-gpu\"
+                       \"--window-size=1920,1080\")"
+  [& args]
+  (let [chrome-options (org.openqa.selenium.chrome.ChromeOptions.)
+        flags (vec (first args))]
+    ;; Call ChromeOptions.addArguments()
+    (.addArguments chrome-options flags)
+    chrome-options))
+
+(defn start-chrome [chromedriver & args]
+  "The default chrome options with the web-driver initialization.
+
+  Example Usage:
+
+  (a) Create chrome-driver without chrome-options :
+
+  (start-chrome \"/usr/lib/chromium/chromedriver\")
+
+  (b) Create chrome-driver with chrome-options :
+
+  (start-chrome \"/usr/lib/chromium/chromedriver\"
+                ;; Arguments for init-chrome-options above.
+                \"headless\"                 ;; Run headless (omit to run non-headless)
+                \"--disable-gpu\"            ;; mandatory argument for Chrome/Chromium 59.0
+                \"--window-size=1920,1080\") ;; optional but good to have
+  For complete options please see https://goo.gl/DcUcrj"
   (let [driver-prop "webdriver.chrome.driver"
         default-exe (System/getProperty driver-prop)
         chromedriver-system "/usr/lib/chromium/chromedriver"
@@ -27,4 +57,6 @@
         (RuntimeException.
           (str "ERROR: chromedriver executable not found:" chromedriver))))
     (System/setProperty driver-prop chromedriver)
-    (instance)))
+    (if args
+      (instance (init-chrome-options args))
+      (instance))))

--- a/src/webica/core.clj
+++ b/src/webica/core.clj
@@ -101,7 +101,37 @@ NOTE: load this namespace first when using webica."
 (def #^{:added "clj0"}
   chrome-driver-extra
   "Extra functions for the chrome-driver ns"
-  "(defn start-chrome [&[chromedriver]]
+  "
+(defn ^:private init-chrome-options
+  \"The default ChromeOptions with the web-driver initialization.
+  e.g.
+  (init-chrome-options \\\"headless\\\"
+                       \\\"--disable-gpu\\\"
+                       \\\"--window-size=1920,1080\\\")\"
+  [& args]
+  (let [chrome-options (org.openqa.selenium.chrome.ChromeOptions.)
+        flags (vec (first args))]
+    ;; Call ChromeOptions.addArguments()
+    (.addArguments chrome-options flags)
+    chrome-options))
+
+(defn start-chrome [chromedriver & args]
+  \"The default chrome options with the web-driver initialization.
+
+  Example Usage:
+
+  (a) Create chrome-driver without chrome-options :
+
+  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\")
+
+  (b) Create chrome-driver with chrome-options :
+
+  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\"
+                ;; Arguments for init-chrome-options above.
+                \\\"headless\\\"                 ;; Run headless (omit to run non-headless)
+                \\\"--disable-gpu\\\"            ;; mandatory argument for Chrome/Chromium 59.0
+                \\\"--window-size=1920,1080\\\") ;; optional but good to have
+  For complete options please see https://goo.gl/DcUcrj\"
   (let [driver-prop \"webdriver.chrome.driver\"
         default-exe (System/getProperty driver-prop)
         chromedriver-system \"/usr/lib/chromium/chromedriver\"
@@ -118,7 +148,9 @@ NOTE: load this namespace first when using webica."
         (RuntimeException.
           (str \"ERROR: chromedriver executable not found:\" chromedriver))))
     (System/setProperty driver-prop chromedriver)
-    (instance)))")
+    (if args
+      (instance (init-chrome-options args))
+      (instance))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra


### PR DESCRIPTION
Hi @tmarble 

This is the interim PR for make it easy to use Chrome with `--headless` option.
It make it possible to run the test without seeing the browser.

It adds the support for [ChromeOptions](https://sites.google.com/a/chromium.org/chromedriver/capabilities)
which make it possible to run Chrome using `headless` options.
Links: [headless chrome](https://developers.google.com/web/updates/2017/04/headless-chrome)
Please let me know if you need any adjustment.

Cheers,
Burin