### PR TITLE
Commented out CIDER dependency in build.boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. This change
 ### [Unreleased]
 
 Changed
-- *TBD*
+- Commented out CIDER dependency in build.boot (Closes #13)
 
 ### [3.0.0-beta2-clj0] - 2016-08-10
 

--- a/build.boot
+++ b/build.boot
@@ -35,19 +35,6 @@
        :scm         {:url project-url}
        :license     {"Apache-2.0" "http://opensource.org/licenses/Apache-2.0"}})
 
-(deftask clj-dev
-  "Clojure REPL for CIDER"
-  []
-  (comp
-    (cider)
-    (repl :server true)
-    (wait)))
-
-(deftask cider-boot
-  "Cider boot params task"
-  []
-  (clj-dev))
-
 (deftask build-target
   "Build the project locally as a JAR."
   [d dir PATH #{str} "the set of directories to write to (target)."]
@@ -72,3 +59,27 @@
    s selenium VERSION str "selenium version [latest]"]
   (set-env! :source-paths #{"generate"})
   (update-code :dry-run dry-run :selenium selenium))
+
+;; For Emacs if you Customize your Cider Boot Parameters to 'cider-boot'
+;; then this task will be invoked upon M-x cider-jack-in
+;; which is on C-c M-j
+;; https://cider.readthedocs.io/en/latest/up_and_running/
+
+;; These tasks is conditional on having cider defined which typically
+;; is done in ~/.boot/profile.boot
+;;
+;; FFI see also: https://github.com/tmarble/tenzing3
+;; Uncomment below if you use CIDER
+
+;; (deftask clj-dev
+;;   "Clojure REPL for CIDER"
+;;   []
+;;   (comp
+;;     (cider)
+;;     (repl :server true)
+;;     (wait)))
+
+;; (deftask cider-boot
+;;   "Cider boot params task"
+;;   []
+;;   (clj-dev))


### PR DESCRIPTION
CIDER users can simply uncomment the block at the bottom of build.boot
(Closes #13)

Added boot.properties explicitly to avoid the warning:
  "Classpath conflict: org.clojure/clojure version 1.8.0
   already loaded, NOT loading version 1.9.0-alpha17"

Signed-off-by: Tom Marble <tmarble@info9.net>