### PR TITLE
Add support for wait/until functions with updated example code

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,14 +1,14 @@
 (def project 'webica)
 (def description "A Clojure binding for Selenium WebDriver")
 (def project-url "https://github.com/tmarble/webica")
-(def selenium-version "3.4.0")
+(def selenium-version "3.8.1")
 (def webica-version "-clj0")
 (def version (str selenium-version webica-version))
 
 (set-env!
   :source-paths #{"src" "test"}
   :dependencies (conj
-                  '[[org.clojure/clojure "1.9.0-alpha17" :scope "provided"]
+                  '[[org.clojure/clojure "1.9.0" :scope "provided"]
                     [camel-snake-kebab "0.4.0"]
                     [environ "1.1.0"]
                     [me.raynes/fs "1.4.6"]

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -22,11 +22,6 @@
     (element/submit q)
     (wait/until wdriver (ec/title-contains search))
     (println (str "current URL of your search : " (driver/get-current-url)))
-    #_
-    ;; TODO: use assert to confirm the result e.g. if the search is "Clojure Conj 2017"
-    ;; the assert would be something like
-    (assert (= "https://www.google.com/search?site=&source=hp&q=Clojure+Conj+2017&oq=&gs_l="
-               (driver/get-current-url)))
     ;; Note: wait for a bit to let the user see the result
     (w/sleep 5)
     (println "Was that so hard?")))
@@ -36,13 +31,7 @@
   [& args]
   (let [search (if (empty? args) "Clojure Conj 2017"
                    (apply str (interpose " " args)))]
-    (let [chrome-binary (chrome/get-chromedriver-binary "/usr/lib/chromium/chromedriver")]
+    (let [chrome-binary (chrome/get-chromedriver-binary)]
       (chrome/start-chrome)
-      #_
-      ;; Or if you prefer to start chrome headlessly
-      (chrome/start-chrome chrome-binary
-                           "headless" ;; uncomment this out to run headless
-                           "--window-size=1024,1080"
-                           "--disable-gpu")
       (lmgtfy search)
       (browser/quit))))

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -37,8 +37,11 @@
   (let [search (if (empty? args) "Clojure Conj 2017"
                    (apply str (interpose " " args)))]
     (let [chrome-binary (chrome/get-chromedriver-binary "/usr/lib/chromium/chromedriver")]
+      (chrome/start-chrome)
+      #_
+      ;; Or if you prefer to start chrome headlessly
       (chrome/start-chrome chrome-binary
-                           ;; "headless" ;; uncomment this out to run headless
+                           "headless" ;; uncomment this out to run headless
                            "--window-size=1024,1080"
                            "--disable-gpu")
       (lmgtfy search)

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -31,7 +31,6 @@
   [& args]
   (let [search (if (empty? args) "Clojure Conj 2017"
                    (apply str (interpose " " args)))]
-    (let [chrome-binary (chrome/get-chromedriver-binary)]
-      (chrome/start-chrome)
-      (lmgtfy search)
-      (browser/quit))))
+    (chrome/start-chrome)
+    (lmgtfy search)
+    (browser/quit)))

--- a/examples/lmgtfy
+++ b/examples/lmgtfy
@@ -3,34 +3,43 @@
 (set-env! :dependencies '[[webica "3.4.0-clj0"]])
 
 (require
-  '[clojure.string :as string]
-  '[webica.core :as w] ;; must always be first
-  '[webica.by :as by]
-  '[webica.web-driver :as driver]
-  '[webica.firefox-driver :as firefox]
-  '[webica.web-element :as element]
-  '[webica.web-driver-wait :as wait]
-  '[webica.remote-web-driver :as browser])
+ '[clojure.string :as string]
+ '[webica.core :as w] ;; must always be first
+ '[webica.by :as by]
+ '[webica.web-driver :as driver]
+ '[webica.firefox-driver :as firefox]
+ '[webica.chrome-driver :as chrome]
+ '[webica.web-element :as element]
+ '[webica.web-driver-wait :as wait]
+ '[webica.expected-conditions :as ec]
+ '[webica.remote-web-driver :as browser])
 
 (defn lmgtfy [search]
   (browser/get "http://www.google.com")
-  (let [q (browser/find-element (by/name "q"))]
+  (let [wdriver (wait/init-web-driver-wait (driver/get-instance))
+        q       (browser/find-element (by/name "q"))]
     (element/send-keys q search)
     (element/submit q)
-    (wait/until (wait/instance 10)
-      (wait/condition
-        (fn [driver]
-          (string/starts-with?
-            (string/lower-case (driver/get-title driver))
-            (string/lower-case search)))))
-    (println "Was that so hard?")
-    (w/sleep 10)))
+    (wait/until wdriver (ec/title-contains search))
+    (println (str "current URL of your search : " (driver/get-current-url)))
+    #_
+    ;; TODO: use assert to confirm the result e.g. if the search is "Clojure Conj 2017"
+    ;; the assert would be something like
+    (assert (= "https://www.google.com/search?site=&source=hp&q=Clojure+Conj+2017&oq=&gs_l="
+               (driver/get-current-url)))
+    ;; Note: wait for a bit to let the user see the result
+    (w/sleep 5)
+    (println "Was that so hard?")))
 
 (defn -main
   "Webica example of 'Let me Google that for you'"
   [& args]
-  (let [search (if (empty? args) "Clojure Conj 2016"
+  (let [search (if (empty? args) "Clojure Conj 2017"
                    (apply str (interpose " " args)))]
-    (firefox/start-firefox)
-    (lmgtfy search)
-    (browser/quit)))
+    (let [chrome-binary (chrome/get-chromedriver-binary "/usr/lib/chromium/chromedriver")]
+      (chrome/start-chrome chrome-binary
+                           ;; "headless" ;; uncomment this out to run headless
+                           "--window-size=1024,1080"
+                           "--disable-gpu")
+      (lmgtfy search)
+      (browser/quit))))

--- a/generate/webica/core.clj
+++ b/generate/webica/core.clj
@@ -171,12 +171,11 @@
   ([]
    (start-chrome (get-chromedriver-binary)))
   ([chromedriver-binary]
-   (start-chrome chromedriver-binary))
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (instance))
   ([chromedriver-binary & args]
    (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
-   (if args
-     (instance (init-chrome-options args))
-     (instance))))")
+   (instance (init-chrome-options args))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra

--- a/generate/webica/core.clj
+++ b/generate/webica/core.clj
@@ -7,7 +7,7 @@
 (ns webica.core
   "Clojure wrapper for Selenium Webdriver
 
-NOTE: load this namespace first when using webica."
+  NOTE: load this namespace first when using webica."
   (:require [clojure.string :as string]
             [clojure.pprint :as pp :refer [pprint]]
             [environ.core :refer [env]]
@@ -18,12 +18,13 @@ NOTE: load this namespace first when using webica."
             Reflector]
            [java.lang.reflect
             InvocationTargetException ParameterizedType Modifier Type]
+           [java.util.concurrent.TimeUnit]
            [com.google.common.collect
             ImmutableList ImmutableMap]
            [org.openqa.selenium
             By Keys WebDriver WebElement]
            [org.openqa.selenium.chrome
-            ChromeDriver ChromeDriverService]
+            ChromeDriver ChromeDriverService ChromeOptions]
            [org.openqa.selenium.firefox
             FirefoxDriver]
            [org.openqa.selenium.interactions
@@ -115,16 +116,51 @@ NOTE: load this namespace first when using webica."
     (.addArguments chrome-options flags)
     chrome-options))
 
-(defn start-chrome [chromedriver & args]
+(def driver-prop \"webdriver.chrome.driver\")
+
+(defn ^:private common-chrome-binary
+  \"Get chromedriver binary from a commonly installed location.\"
+  []
+  (let [default-exe         (System/getProperty driver-prop)
+        chromedriver-system \"/usr/lib/chromium/chromedriver\"
+        chromedriver-local  \"/usr/local/bin/chromedriver\"
+        chromedriver        (or (if (and (not (empty? default-exe))
+                                         (fs/exists? default-exe))
+                                  default-exe)
+                                (if (fs/exists? chromedriver-system)
+                                  chromedriver-system)
+                                chromedriver-local)]
+    chromedriver))
+
+(defn ^:private validate-chromedriver
+  [driver-binary]
+  (if-not (fs/exists? driver-binary)
+    (throw
+     (RuntimeException.
+      (str \"ERROR: chromedriver executable not found:\" driver-binary))))
+  driver-binary)
+
+;; Public apis
+
+(defn get-chromedriver-binary
+  \"Get current chromedriver binary from a given path or from default location.\"
+  ([]
+   (get-chromedriver-binary (common-chrome-binary)))
+  ([driver-binary]
+   (validate-chromedriver driver-binary)))
+
+(defn start-chrome
   \"The default chrome options with the web-driver initialization.
 
   Example Usage:
 
-  (a) Create chrome-driver without chrome-options :
+  (a) Start chrome with the default options from a default binary location
+  (start-chrome)
 
-  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\")
+  (b) Start chrome using the given chromedriver with the default chrome options
+  (start-chrome \\\"/usr/lib/chromium-dev/chromedriver\\\")
 
-  (b) Create chrome-driver with chrome-options :
+  (c) Start chrome using a given chromedriver with list of specific chrome-options :
 
   (start-chrome \\\"/usr/lib/chromium/chromedriver\\\"
                 ;; Arguments for init-chrome-options above.
@@ -132,25 +168,15 @@ NOTE: load this namespace first when using webica."
                 \\\"--disable-gpu\\\"            ;; mandatory argument for Chrome/Chromium 59.0
                 \\\"--window-size=1920,1080\\\") ;; optional but good to have
   For complete options please see https://goo.gl/DcUcrj\"
-  (let [driver-prop \"webdriver.chrome.driver\"
-        default-exe (System/getProperty driver-prop)
-        chromedriver-system \"/usr/lib/chromium/chromedriver\"
-        chromedriver-local \"/usr/local/bin/chromedriver\"
-        chromedriver (or chromedriver
-                     (if (and (not (empty? default-exe))
-                           (fs/exists? default-exe))
-                       default-exe)
-                     (if (fs/exists? chromedriver-system)
-                       chromedriver-system)
-                     chromedriver-local)]
-    (if-not (fs/exists? chromedriver)
-      (throw
-        (RuntimeException.
-          (str \"ERROR: chromedriver executable not found:\" chromedriver))))
-    (System/setProperty driver-prop chromedriver)
-    (if args
-      (instance (init-chrome-options args))
-      (instance))))")
+  ([]
+   (start-chrome (get-chromedriver-binary)))
+  ([chromedriver-binary]
+   (start-chrome chromedriver-binary))
+  ([chromedriver-binary & args]
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (if args
+     (instance (init-chrome-options args))
+     (instance))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra
@@ -217,7 +243,42 @@ NOTE: load this namespace first when using webica."
         (string/lower-case (driver/get-title driver))
         'cheese!'))))\"
   [apply-fn]
-  (Condition. apply-fn))")
+  (Condition. apply-fn))
+
+(def ^:dynamic *default-timeout* 15000) ;; msec
+
+(defn init-web-driver-wait
+  \"Create the WebDriverWait from existing WebDriver object using a given timeout (in msec).\"
+  ([driver]
+    (init-web-driver-wait driver *default-timeout*))
+  ([driver timeout]
+   ;; Set implicitly for a given timeout
+   (let [timeout-in-secs (/ timeout 1000)]
+     (.implicitlyWait
+       (-> driver .manage .timeouts)
+       timeout-in-secs java.util.concurrent.TimeUnit/SECONDS)
+   ;; Then return the WebDriverWait instance
+   (org.openqa.selenium.support.ui.WebDriverWait. driver timeout-in-secs))))
+
+(defn until
+  \"Wait until a given condition is met or raise exception if the condition can't be met.
+
+  Sample usage:
+  ;; a) For the most control try
+  (until wdriver (ec/title-contains \\\"some-text\\\"))
+
+  ;; b) For simple condition with one argument :
+  (until ec/title-is \\\"Google Search - Clojure Conj 2016\\\")
+
+  ;; c) For condition that needed require `by` locator e.g. by/xpath, by/css-selector, etc:
+  (until ec/presence-of-element-located by/xpath \\\"some-id\\\")\"
+
+  ([wdriver expected-fn]
+   (.until wdriver expected-fn))
+  ([wdriver expected-fn arg]
+   (.until wdriver (expected-fn arg)))
+  ([wdriver expected-fn by-fn arg]
+   (.until wdriver (expected-fn (by-fn arg)))))")
 
 (def #^{:added "clj0"}
   web-driver-wait-coercions
@@ -237,6 +298,7 @@ on how to generate the Clojure source code."
                  :require '[[me.raynes.fs :as fs]]
                  :extra chrome-driver-extra}
    ChromeDriverService {}
+   ChromeOptions {}
    FirefoxDriver {:exclude '[get]
                   :clear '[quit kill]
                   :require '[[me.raynes.fs :as fs]]

--- a/src/webica/chrome_driver.clj
+++ b/src/webica/chrome_driver.clj
@@ -79,9 +79,8 @@
   ([]
    (start-chrome (get-chromedriver-binary)))
   ([chromedriver-binary]
-   (start-chrome chromedriver-binary))
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (instance))
   ([chromedriver-binary & args]
    (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
-   (if args
-     (instance (init-chrome-options args))
-     (instance))))
+   (instance (init-chrome-options args))))

--- a/src/webica/chrome_driver.clj
+++ b/src/webica/chrome_driver.clj
@@ -24,16 +24,51 @@
     (.addArguments chrome-options flags)
     chrome-options))
 
-(defn start-chrome [chromedriver & args]
+(def driver-prop "webdriver.chrome.driver")
+
+(defn ^:private common-chrome-binary
+  "Get chromedriver binary from a commonly installed location."
+  []
+  (let [default-exe         (System/getProperty driver-prop)
+        chromedriver-system "/usr/lib/chromium/chromedriver"
+        chromedriver-local  "/usr/local/bin/chromedriver"
+        chromedriver        (or (if (and (not (empty? default-exe))
+                                         (fs/exists? default-exe))
+                                  default-exe)
+                                (if (fs/exists? chromedriver-system)
+                                  chromedriver-system)
+                                chromedriver-local)]
+    chromedriver))
+
+(defn ^:private validate-chromedriver
+  [driver-binary]
+  (if-not (fs/exists? driver-binary)
+    (throw
+     (RuntimeException.
+      (str "ERROR: chromedriver executable not found:" driver-binary))))
+  driver-binary)
+
+;; Public apis
+
+(defn get-chromedriver-binary
+  "Get current chromedriver binary from a given path or from default location."
+  ([]
+   (get-chromedriver-binary (common-chrome-binary)))
+  ([driver-binary]
+   (validate-chromedriver driver-binary)))
+
+(defn start-chrome
   "The default chrome options with the web-driver initialization.
 
   Example Usage:
 
-  (a) Create chrome-driver without chrome-options :
+  (a) Start chrome with the default options from a default binary location
+  (start-chrome)
 
-  (start-chrome \"/usr/lib/chromium/chromedriver\")
+  (b) Start chrome using the given chromedriver with the default chrome options
+  (start-chrome \"/usr/lib/chromium-dev/chromedriver\")
 
-  (b) Create chrome-driver with chrome-options :
+  (c) Start chrome using a given chromedriver with list of specific chrome-options :
 
   (start-chrome \"/usr/lib/chromium/chromedriver\"
                 ;; Arguments for init-chrome-options above.
@@ -41,22 +76,12 @@
                 \"--disable-gpu\"            ;; mandatory argument for Chrome/Chromium 59.0
                 \"--window-size=1920,1080\") ;; optional but good to have
   For complete options please see https://goo.gl/DcUcrj"
-  (let [driver-prop "webdriver.chrome.driver"
-        default-exe (System/getProperty driver-prop)
-        chromedriver-system "/usr/lib/chromium/chromedriver"
-        chromedriver-local "/usr/local/bin/chromedriver"
-        chromedriver (or chromedriver
-                     (if (and (not (empty? default-exe))
-                           (fs/exists? default-exe))
-                       default-exe)
-                     (if (fs/exists? chromedriver-system)
-                       chromedriver-system)
-                     chromedriver-local)]
-    (if-not (fs/exists? chromedriver)
-      (throw
-        (RuntimeException.
-          (str "ERROR: chromedriver executable not found:" chromedriver))))
-    (System/setProperty driver-prop chromedriver)
-    (if args
-      (instance (init-chrome-options args))
-      (instance))))
+  ([]
+   (start-chrome (get-chromedriver-binary)))
+  ([chromedriver-binary]
+   (start-chrome chromedriver-binary))
+  ([chromedriver-binary & args]
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (if args
+     (instance (init-chrome-options args))
+     (instance))))

--- a/src/webica/chrome_options.clj
+++ b/src/webica/chrome_options.clj
@@ -1,0 +1,9 @@
+(ns webica.chrome-options
+  "Clojure binding for Selenium class ChromeOptions"
+  (:require [clojure.core :as clj]
+            [webica.core :as w])
+  (:import [org.openqa.selenium.chrome
+            ChromeOptions]))
+
+(w/intern-java ChromeOptions *ns*)
+

--- a/src/webica/core.clj
+++ b/src/webica/core.clj
@@ -171,12 +171,11 @@
   ([]
    (start-chrome (get-chromedriver-binary)))
   ([chromedriver-binary]
-   (start-chrome chromedriver-binary))
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (instance))
   ([chromedriver-binary & args]
    (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
-   (if args
-     (instance (init-chrome-options args))
-     (instance))))")
+   (instance (init-chrome-options args))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra

--- a/src/webica/core.clj
+++ b/src/webica/core.clj
@@ -7,7 +7,7 @@
 (ns webica.core
   "Clojure wrapper for Selenium Webdriver
 
-NOTE: load this namespace first when using webica."
+  NOTE: load this namespace first when using webica."
   (:require [clojure.string :as string]
             [clojure.pprint :as pp :refer [pprint]]
             [environ.core :refer [env]]
@@ -18,12 +18,13 @@ NOTE: load this namespace first when using webica."
             Reflector]
            [java.lang.reflect
             InvocationTargetException ParameterizedType Modifier Type]
+           [java.util.concurrent.TimeUnit]
            [com.google.common.collect
             ImmutableList ImmutableMap]
            [org.openqa.selenium
             By Keys WebDriver WebElement]
            [org.openqa.selenium.chrome
-            ChromeDriver ChromeDriverService]
+            ChromeDriver ChromeDriverService ChromeOptions]
            [org.openqa.selenium.firefox
             FirefoxDriver]
            [org.openqa.selenium.interactions
@@ -115,16 +116,51 @@ NOTE: load this namespace first when using webica."
     (.addArguments chrome-options flags)
     chrome-options))
 
-(defn start-chrome [chromedriver & args]
+(def driver-prop \"webdriver.chrome.driver\")
+
+(defn ^:private common-chrome-binary
+  \"Get chromedriver binary from a commonly installed location.\"
+  []
+  (let [default-exe         (System/getProperty driver-prop)
+        chromedriver-system \"/usr/lib/chromium/chromedriver\"
+        chromedriver-local  \"/usr/local/bin/chromedriver\"
+        chromedriver        (or (if (and (not (empty? default-exe))
+                                         (fs/exists? default-exe))
+                                  default-exe)
+                                (if (fs/exists? chromedriver-system)
+                                  chromedriver-system)
+                                chromedriver-local)]
+    chromedriver))
+
+(defn ^:private validate-chromedriver
+  [driver-binary]
+  (if-not (fs/exists? driver-binary)
+    (throw
+     (RuntimeException.
+      (str \"ERROR: chromedriver executable not found:\" driver-binary))))
+  driver-binary)
+
+;; Public apis
+
+(defn get-chromedriver-binary
+  \"Get current chromedriver binary from a given path or from default location.\"
+  ([]
+   (get-chromedriver-binary (common-chrome-binary)))
+  ([driver-binary]
+   (validate-chromedriver driver-binary)))
+
+(defn start-chrome
   \"The default chrome options with the web-driver initialization.
 
   Example Usage:
 
-  (a) Create chrome-driver without chrome-options :
+  (a) Start chrome with the default options from a default binary location
+  (start-chrome)
 
-  (start-chrome \\\"/usr/lib/chromium/chromedriver\\\")
+  (b) Start chrome using the given chromedriver with the default chrome options
+  (start-chrome \\\"/usr/lib/chromium-dev/chromedriver\\\")
 
-  (b) Create chrome-driver with chrome-options :
+  (c) Start chrome using a given chromedriver with list of specific chrome-options :
 
   (start-chrome \\\"/usr/lib/chromium/chromedriver\\\"
                 ;; Arguments for init-chrome-options above.
@@ -132,25 +168,15 @@ NOTE: load this namespace first when using webica."
                 \\\"--disable-gpu\\\"            ;; mandatory argument for Chrome/Chromium 59.0
                 \\\"--window-size=1920,1080\\\") ;; optional but good to have
   For complete options please see https://goo.gl/DcUcrj\"
-  (let [driver-prop \"webdriver.chrome.driver\"
-        default-exe (System/getProperty driver-prop)
-        chromedriver-system \"/usr/lib/chromium/chromedriver\"
-        chromedriver-local \"/usr/local/bin/chromedriver\"
-        chromedriver (or chromedriver
-                     (if (and (not (empty? default-exe))
-                           (fs/exists? default-exe))
-                       default-exe)
-                     (if (fs/exists? chromedriver-system)
-                       chromedriver-system)
-                     chromedriver-local)]
-    (if-not (fs/exists? chromedriver)
-      (throw
-        (RuntimeException.
-          (str \"ERROR: chromedriver executable not found:\" chromedriver))))
-    (System/setProperty driver-prop chromedriver)
-    (if args
-      (instance (init-chrome-options args))
-      (instance))))")
+  ([]
+   (start-chrome (get-chromedriver-binary)))
+  ([chromedriver-binary]
+   (start-chrome chromedriver-binary))
+  ([chromedriver-binary & args]
+   (System/setProperty driver-prop (get-chromedriver-binary chromedriver-binary))
+   (if args
+     (instance (init-chrome-options args))
+     (instance))))")
 
 (def #^{:added "clj0"}
   firefox-driver-extra
@@ -217,7 +243,42 @@ NOTE: load this namespace first when using webica."
         (string/lower-case (driver/get-title driver))
         'cheese!'))))\"
   [apply-fn]
-  (Condition. apply-fn))")
+  (Condition. apply-fn))
+
+(def ^:dynamic *default-timeout* 15000) ;; msec
+
+(defn init-web-driver-wait
+  \"Create the WebDriverWait from existing WebDriver object using a given timeout (in msec).\"
+  ([driver]
+    (init-web-driver-wait driver *default-timeout*))
+  ([driver timeout]
+   ;; Set implicitly for a given timeout
+   (let [timeout-in-secs (/ timeout 1000)]
+     (.implicitlyWait
+       (-> driver .manage .timeouts)
+       timeout-in-secs java.util.concurrent.TimeUnit/SECONDS)
+   ;; Then return the WebDriverWait instance
+   (org.openqa.selenium.support.ui.WebDriverWait. driver timeout-in-secs))))
+
+(defn until
+  \"Wait until a given condition is met or raise exception if the condition can't be met.
+
+  Sample usage:
+  ;; a) For the most control try
+  (until wdriver (ec/title-contains \\\"some-text\\\"))
+
+  ;; b) For simple condition with one argument :
+  (until ec/title-is \\\"Google Search - Clojure Conj 2016\\\")
+
+  ;; c) For condition that needed require `by` locator e.g. by/xpath, by/css-selector, etc:
+  (until ec/presence-of-element-located by/xpath \\\"some-id\\\")\"
+
+  ([wdriver expected-fn]
+   (.until wdriver expected-fn))
+  ([wdriver expected-fn arg]
+   (.until wdriver (expected-fn arg)))
+  ([wdriver expected-fn by-fn arg]
+   (.until wdriver (expected-fn (by-fn arg)))))")
 
 (def #^{:added "clj0"}
   web-driver-wait-coercions
@@ -237,6 +298,7 @@ on how to generate the Clojure source code."
                  :require '[[me.raynes.fs :as fs]]
                  :extra chrome-driver-extra}
    ChromeDriverService {}
+   ChromeOptions {}
    FirefoxDriver {:exclude '[get]
                   :clear '[quit kill]
                   :require '[[me.raynes.fs :as fs]]

--- a/src/webica/web_driver_wait.clj
+++ b/src/webica/web_driver_wait.clj
@@ -23,3 +23,38 @@
         'cheese!'))))"
   [apply-fn]
   (Condition. apply-fn))
+
+(def ^:dynamic *default-timeout* 15000) ;; msec
+
+(defn init-web-driver-wait
+  "Create the WebDriverWait from existing WebDriver object using a given timeout (in msec)."
+  ([driver]
+    (init-web-driver-wait driver *default-timeout*))
+  ([driver timeout]
+   ;; Set implicitly for a given timeout
+   (let [timeout-in-secs (/ timeout 1000)]
+     (.implicitlyWait
+       (-> driver .manage .timeouts)
+       timeout-in-secs java.util.concurrent.TimeUnit/SECONDS)
+   ;; Then return the WebDriverWait instance
+   (org.openqa.selenium.support.ui.WebDriverWait. driver timeout-in-secs))))
+
+(defn until
+  "Wait until a given condition is met or raise exception if the condition can't be met.
+
+  Sample usage:
+  ;; a) For the most control try
+  (until wdriver (ec/title-contains \"some-text\"))
+
+  ;; b) For simple condition with one argument :
+  (until ec/title-is \"Google Search - Clojure Conj 2016\")
+
+  ;; c) For condition that needed require `by` locator e.g. by/xpath, by/css-selector, etc:
+  (until ec/presence-of-element-located by/xpath \"some-id\")"
+
+  ([wdriver expected-fn]
+   (.until wdriver expected-fn))
+  ([wdriver expected-fn arg]
+   (.until wdriver (expected-fn arg)))
+  ([wdriver expected-fn by-fn arg]
+   (.until wdriver (expected-fn (by-fn arg)))))

--- a/test/testing/webica/core.clj
+++ b/test/testing/webica/core.clj
@@ -14,7 +14,8 @@
             [webica.remote-web-driver :as browser]
             [webica.web-driver :as driver]
             [webica.web-driver-wait :as wait]
-            [webica.web-element :as element]))
+            [webica.web-element :as element]
+            [webica.expected-conditions :as ec]))
 
 ;; inspired by
 ;; http://docs.seleniumhq.org/docs/03_webdriver.jsp#introducing-the-selenium-webdriver-api-by-example"
@@ -26,23 +27,52 @@
     (element/send-keys q "Cheese!")
     (element/submit q)
     (wait/until (wait/instance 10)
-      (wait/condition
-        (fn [driver]
-          (string/starts-with?
-            (string/lower-case (driver/get-title driver))
-            "cheese!"))))
+                (wait/condition
+                  (fn [driver]
+                    (string/starts-with?
+                      (string/lower-case (driver/get-title driver))
+                      "cheese!"))))
     (w/sleep 2)
     (browser/get-title)))
 
 (deftest testing-webica-core
   (testing "testing-webica-core"
+    #_
     (is (= expected-title
-           (let [_ (firefox/start-firefox)
+           (let [_     (firefox/start-firefox)
                  title (cheese)]
              (browser/quit)
              title)))
     (is (= expected-title
-           (let [_ (chrome/start-chrome)
+           (let [_     (chrome/start-chrome)
                  title (cheese)]
              (browser/quit)
              title)))))
+
+(def search-term "Clojure Conj 2017")
+
+;; Note: the actual url for the above search term is like:
+;; "https://www.google.com/search?site=&source=hp&q=Clojure+Conj+2017&oq=&gs_l="
+(def partial-url (apply str (interpose "+" (clojure.string/split search-term #"\s+"))))
+
+(defn lmgtfy [search]
+  (browser/get "http://www.google.com")
+  (let [wdriver (wait/init-web-driver-wait (driver/get-instance))
+        q       (browser/find-element (by/name "q"))]
+    (element/send-keys q search)
+    (element/submit q)
+    (wait/until wdriver (ec/title-contains search))
+    (driver/get-current-url)))
+
+(deftest testing-webica-core-with-expected-conditions
+  (testing "testing-webica-core-with-expected-conditions"
+    (let [_          (firefox/start-firefox)
+          actual-url (lmgtfy search-term)]
+      (browser/quit)
+      (is (string/includes? actual-url partial-url)))
+
+    (let [chrome-binary (chrome/get-chromedriver-binary "/usr/lib/chromium/chromedriver")
+          _             (chrome/start-chrome chrome-binary "headless") ;; Note: needed chromedriver version 2.30.x+ which support headless
+          actual-url    (lmgtfy search-term)]
+      (browser/quit)
+      (is (string/includes? actual-url partial-url)))))

--- a/test/testing/webica/core.clj
+++ b/test/testing/webica/core.clj
@@ -71,7 +71,7 @@
       (browser/quit)
       (is (string/includes? actual-url partial-url)))
 
-    (let [chrome-binary (chrome/get-chromedriver-binary "/usr/lib/chromium/chromedriver")
+    (let [chrome-binary (chrome/get-chromedriver-binary)
           _             (chrome/start-chrome chrome-binary "headless") ;; Note: needed chromedriver version 2.30.x+ which support headless
           actual-url    (lmgtfy search-term)]
       (browser/quit)


### PR DESCRIPTION
@tmarble 
As I promised, 

This PR is the improved version of wait/until function that I submitted earlier.
What has changes:

- Keep the original api intact if the user wants to use the old api
- Make it possible to wait for some event to happen before acting on it
- Much more efficient than using wait/sleep
- Simplify the logic for getting the chrome driver a bit to keep the code clean

Please let me know if you like any adjustment or if you have any comments.

Cheers,
Burin